### PR TITLE
Update map style dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "classnames": "^2.2.3",
     "file-saver": "^1.3.2",
     "halogen": "^0.2.0",
-    "hsl-map-style": "github:hsldevcom/hsl-map-style#e1ed3f952907cc12e5be393bc2813caa26049350",
+    "hsl-map-style": "github:hsldevcom/hsl-map-style#593a73752aae88ecd99aed9baa27db1d5b9c91e1",
     "immutable": "^3.7.6",
     "lodash": "^4.16.6",
     "moment": "^2.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,9 +2830,9 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-"hsl-map-style@github:hsldevcom/hsl-map-style#e1ed3f952907cc12e5be393bc2813caa26049350":
+"hsl-map-style@github:hsldevcom/hsl-map-style#593a73752aae88ecd99aed9baa27db1d5b9c91e1":
   version "1.0.0"
-  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/e1ed3f952907cc12e5be393bc2813caa26049350"
+  resolved "https://codeload.github.com/hsldevcom/hsl-map-style/tar.gz/593a73752aae88ecd99aed9baa27db1d5b9c91e1"
   dependencies:
     lodash "^4.17.4"
 
@@ -3567,11 +3567,11 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
-"mapbox-gl-function@github:mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525":
+mapbox-gl-function@mapbox/mapbox-gl-function#41c6724e2bbd7bd1eb5991451bbf118b7d02b525:
   version "1.3.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-function/tar.gz/41c6724e2bbd7bd1eb5991451bbf118b7d02b525"
 
-"mapbox-gl-style-spec@github:mapbox/mapbox-gl-style-spec#d11f6d2775bf5b22534b3b2fb3410755b2473cdf":
+mapbox-gl-style-spec@mapbox/mapbox-gl-style-spec#d11f6d2775bf5b22534b3b2fb3410755b2473cdf:
   version "8.11.0"
   resolved "https://codeload.github.com/mapbox/mapbox-gl-style-spec/tar.gz/d11f6d2775bf5b22534b3b2fb3410755b2473cdf"
   dependencies:


### PR DESCRIPTION
Fixes duplicate names in bilingual labels.

Depends on: HSLdevcom/hsl-map-style#27