### PR TITLE
fix(UI): fix moment.js date formatting for "Poikkileikkauspäivä"

### DIFF
--- a/app/components/PointBuildTrigger.js
+++ b/app/components/PointBuildTrigger.js
@@ -99,7 +99,7 @@ export default class RouteMapConfigurator extends Component {
                 </div>
                 <div className={s.content}>
                     <DayPicker
-                        value={moment(this.state.date).format("DD.MM.YYYY")}
+                        value={this.state.date}
                         onChange={(value) => this.setPointDate(value)}
                         disabled={this.isDisabled()}
                     />


### PR DESCRIPTION
The Linjakarttageneraattori poikkileikkaupaiva calendar picker tool
displayed wrongly formatted date in UI and the same date got sent to
back-end as well. This caused the functionality of the date picker to break.

This commit changes the way how moment.js formats the day in PointBuildTrigger.js.
Date formatting with moment.js is already done in DayPicker component and "reformatting"
it twice in PointBuildTrigger caused the bug.