### PR TITLE
MM-329 - Add filtering by parsed jore_id

### DIFF
--- a/app/actions/routeMapConfiguration.js
+++ b/app/actions/routeMapConfiguration.js
@@ -21,6 +21,7 @@ export const TOGGLE_ONLY_NEAR_BUSES = "TOGGLE_ONLY_NEAR_BUSES";
 export const TOGGLE_ZONE_SYMBOLS = "TOGGLE_ZONE_SYMBOLS";
 export const SET_SYMBOL_SIZE = "SET_SYMBOL_SIZE";
 export const LOAD_STATE = "LOAD_STATE";
+export const TOGGLE_JORE_ID_FILTERING = "TOGGLE_JORE_ID_FILTERING";
 
 export function setBuild(id) {
     return {
@@ -136,5 +137,11 @@ export function setSymbolSize(size) {
     return {
         type: SET_SYMBOL_SIZE,
         data: size
+    };
+}
+
+export function toggleJoreIdFiltering() {
+    return {
+        type: TOGGLE_JORE_ID_FILTERING
     };
 }

--- a/app/components/RouteMapConfigurator.js
+++ b/app/components/RouteMapConfigurator.js
@@ -30,6 +30,7 @@ export default class RouteMapConfigurator extends Component {
         this.setSymbolSize = this.setSymbolSize.bind(this);
         this.selectSymbol = this.selectSymbol.bind(this);
         this.addSymbol = this.addSymbol.bind(this);
+        this.toggleJoreIdFiltering = this.toggleJoreIdFiltering.bind(this);
 
         this.routesLayer = this.props.layers.find(
             (layer) => layer.id === "routes"
@@ -92,6 +93,10 @@ export default class RouteMapConfigurator extends Component {
 
     toggleZoneSymbols() {
         this.props.toggleZoneSymbols();
+    }
+
+    toggleJoreIdFiltering() {
+        this.props.toggleJoreIdFiltering();
     }
 
     openAdvancedSettings() {
@@ -173,6 +178,18 @@ export default class RouteMapConfigurator extends Component {
                                     )
                                 }
                                 placeholder="joreId1,joreId2"
+                            />
+                        </div>
+                    </div>
+                    <div className={style.element}>
+                        <div className={style.title}>Käytä jore-id:tä</div>
+                        <div className={style.value}>
+                            <input
+                                className={style.checkbox}
+                                type="checkbox"
+                                onChange={this.toggleJoreIdFiltering}
+                                value={this.props.useJoreId}
+                                checked={this.props.useJoreId}
                             />
                         </div>
                     </div>

--- a/app/containers/Map.js
+++ b/app/containers/Map.js
@@ -20,7 +20,8 @@ function mapStateToProps(state) {
         style: styleFromLayers(
             state.layers,
             date,
-            state.routeMapConfiguration.get("routeFilter")
+            state.routeMapConfiguration.get("routeFilter"),
+            state.routeMapConfiguration.get("useJoreId")
         ),
         mapWidth: state.layout.mapWidth,
         mapHeight: state.layout.mapHeight,

--- a/app/containers/RouteMapConfigurator.js
+++ b/app/containers/RouteMapConfigurator.js
@@ -7,7 +7,8 @@ import {
     setRouteFilter,
     toggleOnlyNearBuses,
     toggleZoneSymbols,
-    setSymbolSize
+    setSymbolSize,
+    toggleJoreIdFiltering
 } from "../actions/routeMapConfiguration";
 import {addSymbol} from "../actions/viewport";
 import RouteMapConfigurator from "../components/RouteMapConfigurator";
@@ -24,7 +25,8 @@ function mapStateToProps(state) {
         showOnlyNearBuses: state.routeMapConfiguration.get("onlyNearBuses"),
         showZoneSymbols: state.routeMapConfiguration.get("zoneSymbols"),
         pointConfig: state.publisherRequests.pointConfig,
-        symbolSize: state.routeMapConfiguration.get("symbolSize")
+        symbolSize: state.routeMapConfiguration.get("symbolSize"),
+        useJoreId: state.routeMapConfiguration.get("useJoreId")
     };
 }
 
@@ -40,7 +42,8 @@ function mapDispatchToProps(dispatch) {
             toggleZoneSymbols,
             setSymbolSize,
             setLayer,
-            addSymbol
+            addSymbol,
+            toggleJoreIdFiltering
         },
         dispatch
     );

--- a/app/reducers/routeMapConfiguration.js
+++ b/app/reducers/routeMapConfiguration.js
@@ -18,7 +18,8 @@ import {
     TOGGLE_ONLY_NEAR_BUSES,
     TOGGLE_ZONE_SYMBOLS,
     SET_SYMBOL_SIZE,
-    LOAD_STATE
+    LOAD_STATE,
+    TOGGLE_JORE_ID_FILTERING
 } from "../actions/routeMapConfiguration";
 
 const initialState = fromJS({
@@ -38,7 +39,8 @@ const initialState = fromJS({
     stationFontSize: 12,
     onlyNearBuses: false,
     zoneSymbols: false,
-    symbolSize: "200px"
+    symbolSize: "200px",
+    useJoreId: false
 });
 
 export default function routeMapConfiguration(state = initialState, action) {
@@ -89,6 +91,9 @@ export default function routeMapConfiguration(state = initialState, action) {
                 newState = newState.set(key, routeConfig[key]);
             });
             return newState;
+        }
+        case TOGGLE_JORE_ID_FILTERING: {
+            return state.set("useJoreId", !state.get("useJoreId"));
         }
         default:
             return state;

--- a/app/utils/map-utils.js
+++ b/app/utils/map-utils.js
@@ -28,20 +28,36 @@ const mapLayers = (layers) => {
     return ret;
 };
 
-export const styleFromLayers = memoize((layers, date, routeFilter) => {
-    const style = hslMapStyle.generateStyle({
-        components: mapLayers(layers),
-        routeFilter
-    });
-
-    sourcesWithDate.forEach((key) => {
-        if (style.sources[key] && style.sources[key].url) {
-            style.sources[key].url += `?date=${date}`;
+const parseRouteFilterIds = (routeFilter, useJoreId) => {
+    if (routeFilter.length >= 0) {
+        if (!useJoreId) {
+            const mappedFilter = routeFilter.map((filter) => {
+                return {idParsed: filter};
+            });
+            return mappedFilter;
         }
-    });
+        return routeFilter;
+    }
+    return [];
+};
 
-    return style;
-});
+export const styleFromLayers = memoize(
+    (layers, date, routeFilter, useJoreId) => {
+        console.log(useJoreId);
+        const style = hslMapStyle.generateStyle({
+            components: mapLayers(layers),
+            routeFilter: parseRouteFilterIds(routeFilter, useJoreId)
+        });
+
+        sourcesWithDate.forEach((key) => {
+            if (style.sources[key] && style.sources[key].url) {
+                style.sources[key].url += `?date=${date}`;
+            }
+        });
+
+        return style;
+    }
+);
 
 export const createMapOptions = (mapSelection) => {
     const tileScale = mapSelectionToTileScale(mapSelection);
@@ -76,19 +92,6 @@ export const createMapOptions = (mapSelection) => {
         mapOptions.zoneSymbolSize = mapSelection.zoneSymbolSize;
     }
     return mapOptions;
-};
-
-const parseRouteFilterIds = (routeFilter, useJoreId) => {
-    if (routeFilter.length >= 0) {
-        if (!useJoreId) {
-            const mappedFilter = routeFilter.map((filter) => {
-                return {idParsed: filter};
-            });
-            return mappedFilter;
-        }
-        return routeFilter;
-    }
-    return [];
 };
 
 export const createConfigurationOptions = (configuration, pointConfig) => ({

--- a/app/utils/map-utils.js
+++ b/app/utils/map-utils.js
@@ -78,10 +78,26 @@ export const createMapOptions = (mapSelection) => {
     return mapOptions;
 };
 
+const parseRouteFilterIds = (routeFilter, useJoreId) => {
+    if (routeFilter.length >= 0) {
+        if (!useJoreId) {
+            const mappedFilter = routeFilter.map((filter) => {
+                return {idParsed: filter};
+            });
+            return mappedFilter;
+        }
+        return routeFilter;
+    }
+    return [];
+};
+
 export const createConfigurationOptions = (configuration, pointConfig) => ({
     date: moment(pointConfig.target_date).format("YYYY-MM-DD"),
     name: configuration.get("posterName"),
-    routeFilter: configuration.get("routeFilter"),
+    routeFilter: parseRouteFilterIds(
+        configuration.get("routeFilter"),
+        configuration.get("useJoreId")
+    ),
     scaleFontSize: configuration.get("scaleFontSize"),
     scaleLength: configuration.get("scaleLength"),
     maxAnchorLength: configuration.get("maxAnchorLineLength"),


### PR DESCRIPTION
Added UI elements to enable filtering the routemap with parsed IDs as well as regular jore IDs. Parsed ID filtering enabled by default.