### PR TITLE
AB#28974: Represent zone symbols correctly in UI in regards to prints

### DIFF
--- a/app/components/Map.js
+++ b/app/components/Map.js
@@ -8,13 +8,12 @@ const MapComponent = ({
     viewport,
     updateViewport,
     style,
-    mapWidth,
-    mapHeight,
     zoneSymbols,
     updateSymbol,
     showZoneSymbols,
     symbolSize,
-    mapSelectionSize
+    mapSelectionSize,
+    mapSelection
 }) => {
     const mapContainerRef = useRef(null);
     const [map, setMap] = useState(null);
@@ -65,9 +64,7 @@ const MapComponent = ({
                     zoneSymbols={zoneSymbols}
                     updateSymbol={updateSymbol}
                     symbolSize={symbolSize}
-                    mapWidth={mapWidth}
-                    mapHeight={mapHeight}
-                    mapSelectionSize={mapSelectionSize}
+                    mapSelection={mapSelection}
                 />
             )}
         </div>

--- a/app/components/SelectionMarker.js
+++ b/app/components/SelectionMarker.js
@@ -4,7 +4,12 @@ import {List} from "immutable";
 import {mapSelectionToBbox} from "../utils/geom-utils";
 import styles from "./Marker.css";
 
-function redrawSelectionWindow({map, canvas, mapSelection, updateSelectionSize}) {
+function redrawSelectionWindow({
+    map,
+    canvas,
+    mapSelection,
+    updateSelectionSize
+}) {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     // eslint-disable-next-line no-param-reassign
@@ -19,7 +24,7 @@ function redrawSelectionWindow({map, canvas, mapSelection, updateSelectionSize})
     ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.clearRect(nw.x, nw.y, se.x - nw.x, se.y - nw.y);
-    const selectionWidth = Math.abs(nw.x - se.x);	
+    const selectionWidth = Math.abs(nw.x - se.x);
     const selectionHeight = Math.abs(nw.y - se.y);
     if (updateSelectionSize) {
         updateSelectionSize([selectionWidth, selectionHeight]);
@@ -45,7 +50,10 @@ const SelectionMarker = ({
         if (!mapSelectionSize) {
             const newCenter = List([24.9, 60.2]);
             const updatedMapSelection = mapSelection.set("center", newCenter);
-            updateSelectionSize([updatedMapSelection.get("size").get(0), updatedMapSelection.get("size").get(1)]);
+            updateSelectionSize([
+                updatedMapSelection.get("size").get(0),
+                updatedMapSelection.get("size").get(1)
+            ]);
             return () => {};
         }
 
@@ -65,23 +73,41 @@ const SelectionMarker = ({
             const lngLat = e.target.getLngLat();
             const newCenter = List([lngLat.lng, lngLat.lat]);
             const updatedMapSelection = mapSelection.set("center", newCenter);
-            redrawSelectionWindow({map, canvas: canvasRef.current, mapSelection: updatedMapSelection});
+            redrawSelectionWindow({
+                map,
+                canvas: canvasRef.current,
+                mapSelection: updatedMapSelection
+            });
         };
 
         const handleDragEnd = (e) => {
             const lngLat = e.target.getLngLat();
             const newCenter = List([lngLat.lng, lngLat.lat]);
             const updatedMapSelection = mapSelection.set("center", newCenter);
-            redrawSelectionWindow({map, canvas: canvasRef.current, mapSelection: updatedMapSelection, updateSelectionSize});
+            redrawSelectionWindow({
+                map,
+                canvas: canvasRef.current,
+                mapSelection: updatedMapSelection,
+                updateSelectionSize
+            });
             updateCenter(newCenter);
         };
 
         const handleMapMove = () => {
-            redrawSelectionWindow({map, canvas: canvasRef.current, mapSelection});
+            redrawSelectionWindow({
+                map,
+                canvas: canvasRef.current,
+                mapSelection
+            });
         };
 
         const handleZoomEnd = () => {
-            redrawSelectionWindow({map, canvas: canvasRef.current, mapSelection, updateSelectionSize});
+            redrawSelectionWindow({
+                map,
+                canvas: canvasRef.current,
+                mapSelection,
+                updateSelectionSize
+            });
         };
 
         marker.on("drag", handleDrag);
@@ -96,7 +122,12 @@ const SelectionMarker = ({
         canvas.style.pointerEvents = "none";
         map.getContainer().appendChild(canvas);
         canvasRef.current = canvas;
-        redrawSelectionWindow({map, canvas: canvasRef.current, mapSelection, updateSelectionSize});
+        redrawSelectionWindow({
+            map,
+            canvas: canvasRef.current,
+            mapSelection,
+            updateSelectionSize
+        });
 
         return () => {
             marker.off("drag", handleDrag);

--- a/app/components/ZoneSymbolMarkers.js
+++ b/app/components/ZoneSymbolMarkers.js
@@ -11,8 +11,6 @@ import {
     mapSelectionToMeterPerPixelRatio
 } from "../utils/geom-utils";
 
-const SCALE = 96 / 72;
-
 const getZoneIcon = (zone, svgSize) => {
     switch (zone) {
         case "A":
@@ -38,9 +36,9 @@ const getSymbolSize = (symbolSize, mapSelection, map) => {
 
     // We can calculate the ratio of the symbol's diameter to the mapSelection's diameter
     const mapSelectionBbox = mapSelectionToBbox(mapSelection);
-    const bboxInMeters = bboxDiameterInMeters(mapSelectionBbox)
-    const symbolToMapSelectionRatio = symbolDiameterInMeters / bboxInMeters
-    
+    const bboxInMeters = bboxDiameterInMeters(mapSelectionBbox);
+    const symbolToMapSelectionRatio = symbolDiameterInMeters / bboxInMeters;
+
     // Get mapSelection coordinates in pixel coordinates
     const bboxNw = map.project(mapSelectionBbox[0]);
     const bboxSe = map.project(mapSelectionBbox[1]);
@@ -48,7 +46,9 @@ const getSymbolSize = (symbolSize, mapSelection, map) => {
     // Calculate mapSelection diameter in pixels
     const widthInPixels = Math.abs(bboxSe.x - bboxNw.x);
     const heightInPixels = Math.abs(bboxSe.y - bboxNw.y);
-    const bboxDiameter = Math.sqrt(widthInPixels * widthInPixels + heightInPixels * heightInPixels);
+    const bboxDiameter = Math.sqrt(
+        widthInPixels * widthInPixels + heightInPixels * heightInPixels
+    );
 
     // Finally get the symbol's diameter in pixels relative to the map
     const symbolSizeToMapScale = bboxDiameter * symbolToMapSelectionRatio;
@@ -61,7 +61,7 @@ const ZoneSymbolMarkers = ({
     zoneSymbols,
     updateSymbol,
     symbolSize,
-    mapSelection,
+    mapSelection
 }) => {
     const markersRef = useRef([]);
 
@@ -73,11 +73,7 @@ const ZoneSymbolMarkers = ({
         markersRef.current.forEach((marker) => marker.remove());
         markersRef.current = [];
 
-        const svgSize = getSymbolSize(
-            symbolSize,
-            mapSelection,
-            map
-        );
+        const svgSize = getSymbolSize(symbolSize, mapSelection, map);
         zoneSymbols.forEach((symbol) => {
             const markerElement = document.createElement("div");
             ReactDOM.render(
@@ -109,11 +105,7 @@ const ZoneSymbolMarkers = ({
         }
 
         const resizeMarkers = () => {
-            const newSvgSize = getSymbolSize(
-                symbolSize,
-                mapSelection,
-                map
-            );
+            const newSvgSize = getSymbolSize(symbolSize, mapSelection, map);
             markersRef.current.forEach((marker) => {
                 const element = marker.getElement();
                 if (marker.symbol) {

--- a/app/components/ZoneSymbolMarkers.js
+++ b/app/components/ZoneSymbolMarkers.js
@@ -24,13 +24,21 @@ const getZoneIcon = (zone, svgSize) => {
 };
 
 const getSymbolSize = (symbolSize, mapWidth, mapHeight, mapSelectionSize) => {
-    // This is not the correct way to calculate this. Using mapSelectionSize here doesnt make sense
     const symbolSizeNum = parseInt(symbolSize.replace("px", ""), 10);
-    const mapSizeDiameter = (mapWidth + mapHeight) / 2;
-    const symbolToMapRatio = mapSizeDiameter / symbolSizeNum;
-    const mapSelectionSizeDiameter = (mapSelectionSize[0] + mapSelectionSize[1]) / 2;
 
-    return (mapSelectionSizeDiameter / symbolToMapRatio) * SCALE;
+    // Calculate the average of map width and height
+    const mapSizeDiameter = (mapWidth + mapHeight) / 2;
+
+    // Calculate the ratio of the symbol size to the map size
+    const symbolToMapRatio = (symbolSizeNum / mapSizeDiameter) * SCALE;
+
+    const selectionDiameter = Math.sqrt(
+        mapSelectionSize[0] ** 2 + mapSelectionSize[1] ** 2
+    );
+
+    const correctedSymbolSize = selectionDiameter * symbolToMapRatio;
+
+    return correctedSymbolSize;
 };
 
 const ZoneSymbolMarkers = ({

--- a/app/components/ZoneSymbolMarkers.js
+++ b/app/components/ZoneSymbolMarkers.js
@@ -117,9 +117,9 @@ const ZoneSymbolMarkers = ({
             });
         };
 
-        map.on("zoomend", resizeMarkers);
+        map.on("zoom", resizeMarkers);
 
-        return () => map.off("zoomend", resizeMarkers);
+        return () => map.off("zoom", resizeMarkers);
     }, [symbolSize]);
 
     return null;

--- a/app/utils/geom-utils.js
+++ b/app/utils/geom-utils.js
@@ -95,7 +95,7 @@ export const bboxDiameterInMeters = (bbox) => {
     const latDiffMeters = latDiff * DEG_LAT_PER_M;
     const lngDiffMeters = lngDiff * degLonPerM((lat1 + lat2) / 2);
 
-    const diameter = Math.sqrt(Math.pow(latDiffMeters, 2) + Math.pow(lngDiffMeters, 2));
+    const diameter = Math.sqrt(latDiffMeters ** 2 + lngDiffMeters ** 2);
 
     return diameter;
 };

--- a/app/utils/geom-utils.js
+++ b/app/utils/geom-utils.js
@@ -82,3 +82,20 @@ export const mapSelectionToMeterPerPixelRatio = (mapSelection) => {
         mapSelection.get("mapScale");
     return Math.round(widthIRLMeters / widthInPixels);
 };
+
+export const bboxDiameterInMeters = (bbox) => {
+    if (!bbox || bbox.length !== 2) return 0;
+
+    const [lng1, lat1] = bbox[0];
+    const [lng2, lat2] = bbox[1];
+
+    const latDiff = lat2 - lat1;
+    const lngDiff = lng2 - lng1;
+
+    const latDiffMeters = latDiff * DEG_LAT_PER_M;
+    const lngDiffMeters = lngDiff * degLonPerM((lat1 + lat2) / 2);
+
+    const diameter = Math.sqrt(Math.pow(latDiffMeters, 2) + Math.pow(lngDiffMeters, 2));
+
+    return diameter;
+};


### PR DESCRIPTION
Tweak the symbol sizing in order to get them closer to what the prints display