### PR TITLE
AB#53258: Fix map generator appearing in google search results (#138)

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -7,6 +7,7 @@
 			name="viewport"
 			content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"
 		/>
+		<meta name="robots" content="noindex, nofollow" />
 		<link
 			href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.2.1/mapbox-gl.css"
 			rel="stylesheet"


### PR DESCRIPTION
Cherry-pick: Production environment SEO fix to prevent map generator appearing in google search results.